### PR TITLE
'getAudience' -fix

### DIFF
--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -97,7 +97,7 @@ class PushSubscription implements PushSubscriptionContract
      */
     public function getAudience(): string
     {
-        $audience = new Request('', $this->getEndpoint());
+        $audience = new Request('get', $this->getEndpoint());
 
         return $audience->getUri()->getScheme() . '://' . $audience->getUri()->getHost();
     }


### PR DESCRIPTION
Fixed the 'getAudience' issue. The empty method was preventing you to retrieve the Audience and resulted in a exception that was being thrown.